### PR TITLE
Allow deploy-to-testpypi to fail in ci

### DIFF
--- a/.github/workflows/dev_test_deploy.yml
+++ b/.github/workflows/dev_test_deploy.yml
@@ -55,3 +55,4 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
           twine upload --repository testpypi dist/*
+        continue-on-error: true


### PR DESCRIPTION
The deployment to testpypi may fail if we try to upload the same version
twice. This scenario can occur if we have to make changes to develop
post merging a feature, but before merging it to master. This error prevents 
us from merging our changes into master as the ci job considers it a failure.
Hence the change to the ci behavior to not treat deploy-to-testpypi as a failure.